### PR TITLE
Add working .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,226 @@
+#sudo: required
+dist: bionic
+language: cpp
+cache: ccache
+#os:
+#- linux
+#- osx
+
+#compiler:
+#- gcc
+#- clang
+common_sources: &all_sources
+- ubuntu-toolchain-r-test
+- llvm-toolchain-trusty
+- llvm-toolchain-trusty-3.9
+- llvm-toolchain-trusty-4.0
+- llvm-toolchain-xenial-5.0
+- llvm-toolchain-xenial-6.0
+
+matrix:
+  include:
+
+    # 1/ Linux Clang Builds
+
+    - os: linux
+      compiler: clang
+      addons:
+          apt:
+              sources: *all_sources
+              packages: ['clang-3.9']
+      env: COMPILER='clang++-3.9'
+
+    - os: linux
+      compiler: clang
+      addons:
+          apt:
+              sources: *all_sources
+              packages: ['clang-4.0']
+      env: COMPILER='clang++-4.0'
+
+    - os: linux
+      dist: bionic
+      compiler: clang
+      addons:
+          apt:
+              sources: *all_sources
+              packages: ['clang-5.0']
+      env: COMPILER='clang++-5.0'
+
+    - os: linux
+      dist: bionic
+      compiler: clang
+      addons:
+          apt:
+              sources: *all_sources
+              packages: ['clang-6.0']
+      env: COMPILER='clang++-6.0'
+
+    # 2/ Linux GCC Builds
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources: *all_sources
+          packages: ['g++-5']
+      env: COMPILER='g++-5'
+
+    - os: linux
+      compiler: gcc
+      addons: &gcc6
+        apt:
+          sources: *all_sources
+          packages: ['g++-6']
+      env: COMPILER='g++-6'
+
+    - os: linux
+      compiler: gcc
+      addons: &gcc7
+        apt:
+          sources: *all_sources
+          packages: ['g++-7']
+      env: COMPILER='g++-7'
+
+    - os: linux
+      compiler: gcc
+      addons: &gcc8
+        apt:
+          sources: *all_sources
+          packages: ['g++-8']
+      env: COMPILER='g++-8'
+
+    # 3b/ Linux C++14 Clang builds
+    # Note that we need newer libstdc++ for C++14 support
+    - os: linux
+      compiler: clang
+      addons:
+          apt:
+              sources: *all_sources
+              packages: ['clang-3.9', 'libstdc++-6-dev']
+      env: COMPILER='clang++-3.9' CPP17=1
+
+    - os: linux
+      compiler: clang
+      addons:
+          apt:
+              sources: *all_sources
+              packages: ['clang-4.0', 'libstdc++-6-dev']
+      env: COMPILER='clang++-4.0' CPP17=1
+
+    - os: linux
+      dist: bionic
+      compiler: clang
+      addons:
+          apt:
+              sources: *all_sources
+              packages: ['clang-5.0', 'libstdc++-6-dev']
+      env: COMPILER='clang++-5.0' CPP17=1
+
+    - os: linux
+      dist: bionic
+      compiler: clang
+      addons:
+          apt:
+              sources: *all_sources
+              packages: ['clang-6.0', 'libstdc++-6-dev']
+      env: COMPILER='clang++-6.0' CPP17=1
+
+
+    # 4a/ Linux C++14 GCC builds
+    - os: linux
+      compiler: gcc
+      addons: *gcc6
+      env: COMPILER='g++-6'
+
+    - os: linux
+      compiler: gcc
+      addons: *gcc7
+      env: COMPILER='g++-7'
+
+    - os: linux
+      compiler: gcc
+      addons: *gcc8
+      env: COMPILER='g++-8'
+
+    # 5/ OSX Clang Builds
+
+    # - os: osx
+    #   osx_image: xcode9
+    #   compiler: clang
+    #   env: COMPILER='clang++'
+
+    # - os: osx
+    #   osx_image: xcode9.1
+    #   compiler: clang
+    #   env: COMPILER='clang++'
+
+    # - os: osx
+    #   osx_image: xcode9.1
+    #   compiler: clang
+    #   env: COMPILER='clang++' CPP17=1
+
+    - os: osx
+      osx_image: xcode10.3
+      compiler: clang
+      env: COMPILER='clang++'
+
+    - os: osx
+      osx_image: xcode10.3
+      compiler: clang
+      env: COMPILER='clang++' CPP17=1
+
+    - os: osx
+      osx_image: xcode11.2
+      compiler: clang
+      env: COMPILER='clang++'
+
+    - os: osx
+      osx_image: xcode11.2
+      compiler: clang
+      env: COMPILER='clang++' CPP17=1
+
+before install:
+
+install:
+#- sudo apt-get update -qq
+# - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
+# - mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}
+# if [[ "${TRAVIS_OS_NAME}" == "linux" ]];
+#     CMAKE_URL="http://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.tar.gz"
+#     mkdir cmake && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
+#     export PATH=${DEPS_DIR}/cmake/bin:${PATH}
+# - |
+#   if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+#     which cmake || brew install cmake;
+#   fi
+
+
+before_script:
+#- export CXX=${COMPILER}
+- |
+  if [[ ${CPP17} -eq 1 ]]; then
+    export CPP_STANDARD=17
+  elif [[ ${CPP14} -eq 1 ]]; then
+    export CPP_STANDARD=14
+  else
+    export CPP_STANDARD=11
+  fi
+- cd .. && pwd
+- wget https://github.com/chriskohlhoff/asio/archive/asio-1-14-0.tar.gz && mkdir asio && tar -zxvf asio-1-14-0.tar.gz -C asio --strip-components=1
+- wget https://github.com/catchorg/Catch2/archive/v2.10.2.tar.gz && mkdir Catch2 && tar -zxvf v2.10.2.tar.gz -C Catch2 --strip-components=1
+- wget https://github.com/martinmoene/ring-span-lite/archive/v0.3.0.tar.gz && mkdir ring-span-lite && tar -zxvf v0.3.0.tar.gz -C ring-span-lite --strip-components=1
+- wget https://github.com/JustasMasiulis/circular_buffer/archive/master.tar.gz && mkdir circular_buffer && tar -zxvf master.tar.gz -C circular_buffer --strip-components=1
+#- pwd && ls
+- mkdir build && cd build && ls
+#- pwd && ls
+- cmake ../utility-rack/
+
+script:
+#- pwd && ls
+- make all
+- make test
+
+#branches:
+#only:
+#-master
+#-addTravisCI


### PR DESCRIPTION
This pull request adds a working .yml file for TravisCI into the `develop` branch to test utility rack on the following platforms:

| OS | Compiler |
| --- | --- |
| Linux | Clang++ 3.9 |
| | Clang++ 4.0  |
| | Clang++ 5.0 |
| |Clang++ 6.0 |
| |g++ 5 |
| |g++ 6 |
| |g++ 7 |
| |g++ 8|
|MacOS | Clang++ / XCode 10.3|
||  Clang++ / XCode 11.2 |

I cherry-picked the commit to only grab the working version and not grab the full chain of irrelevant intermediate steps from the `addTravisCI` branch. 
